### PR TITLE
Update for install not working on Ubuntu 17.04

### DIFF
--- a/fetchlibs.sh
+++ b/fetchlibs.sh
@@ -59,7 +59,7 @@ cd bin/fuzzer-libs
 
 LIBS="libc-bin libstdc++6"
 fetcharch armhf ubuntu trusty
-fetcharch armel ubuntu precise
+fetcharch armel debian jessie
 fetcharch powerpc ubuntu trusty
 fetcharch arm64 ubuntu trusty
 fetcharch i386 ubuntu trusty


### PR DESCRIPTION
This seems to "fix" the install issues of ubuntu not supporting armel and possibly dropping the keys.

See #4 