### PR TITLE
Import check

### DIFF
--- a/shellphish_afl/__init__.py
+++ b/shellphish_afl/__init__.py
@@ -1,6 +1,9 @@
 import os
 import distutils
 
+if not hasattr(distutils, 'sysconfig'):
+    import distutils.sysconfig
+
 def afl_bin(platform):
     return os.path.join(afl_dir(platform), 'afl-fuzz')
 


### PR DESCRIPTION
Ran into this issue when installing shellphish-afl into the core python library (root) instead of a virtualenv. Not sure why the distutils are different in this way, but if you import the full path in my case it fixes that.