### PR TITLE
Replace 'jessie' with 'stretch' for mips & mipsel

### DIFF
--- a/fetchlibs.sh
+++ b/fetchlibs.sh
@@ -63,7 +63,7 @@ fetcharch armel debian jessie
 fetcharch powerpc ubuntu trusty
 fetcharch arm64 ubuntu trusty
 fetcharch i386 ubuntu trusty
-fetcharch mips debian jessie
-fetcharch mipsel debian jessie
+fetcharch mips debian stretch
+fetcharch mipsel debian stretch
 
 # mini debootstrap 


### PR DESCRIPTION
As mips is deleted from jessie, replace it with stretch. https://lists.debian.org/debian-devel-announce/2019/03/msg00006.html